### PR TITLE
chore(docs): adds Cosmic to Command Line libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,7 @@ Libraries to help manage database schemas and migrations.
 * [CLImate](https://github.com/thephpleague/climate) - A library for outputting colors and special formatting.
 * [Commando](https://github.com/nategood/commando) - Another simple command line opt parser.
 * [Cron Expression](https://github.com/mtdowling/cron-expression) - A library to calculate cron run dates.
+* [Cosmic](https://github.com/diego-ninja/cosmic) - A tool and a framework to build powerful and nice CLI applications.
 * [GetOpt](https://github.com/getopt-php/getopt-php) - A command line opt parser.
 * [GetOptionKit](https://github.com/c9s/GetOptionKit) - Another command line opt parser.
 * [PsySH](https://github.com/bobthecow/psysh) - Another PHP REPL.


### PR DESCRIPTION
Adds Cosmic to the Command Line section, Cosmic is on one hand a kind of framework to build CLI apps, focused on eye candy, simplicity, and RAD, and on the other hand is a CLI app for generating, installing signing, and publishing CLI apps.

Cosmic is in a very advanced beta stage, it is perfectly usable but any help and contributions to improve the documentation, add new features, or refactor some parts of the code are welcome, help with GitHub actions and pages is very appreciated too.

So, if you consider adding the project to your list it will be _the awesomest_, if not, it's okay anyway. I understand you are not going to add every single project to an **awesome** list, it will lose the awesome thing so fast... 